### PR TITLE
Moved in rob's changes and other stuff (#343)

### DIFF
--- a/FlashLFQ/FlashLFQ.csproj
+++ b/FlashLFQ/FlashLFQ.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\Chemistry\Chemistry.csproj" />
     <ProjectReference Include="..\MassSpectrometry\MassSpectrometry.csproj" />
     <ProjectReference Include="..\MzML\MzML.csproj" />
     <ProjectReference Include="..\Spectra\Spectra.csproj" />
@@ -27,12 +26,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="SharpLearning.Containers">
-      <Version>0.28.0</Version>
-    </PackageReference>
-    <PackageReference Include="SharpLearning.Optimization">
-      <Version>0.28.0</Version>
-    </PackageReference>
+    <PackageReference Include="SharpLearning.Containers" Version="[0.28.0]" />
+    <PackageReference Include="SharpLearning.Optimization" Version="[0.28.0]" />
   </ItemGroup>
   
 </Project>

--- a/FlashLFQ/FlashLfqEngine.cs
+++ b/FlashLFQ/FlashLfqEngine.cs
@@ -605,13 +605,20 @@ namespace FlashLFQ
 
             Parallel.ForEach(Partitioner.Create(0, identifications.Count),
                 new ParallelOptions { MaxDegreeOfParallelism = maxThreads },
-                range =>
+                (range, loopState) =>
             {
                 List<IndexedMassSpectralPeak> binPeaks = new List<IndexedMassSpectralPeak>();
                 List<IsotopicEnvelope> isotopicEnvelopes = new List<IsotopicEnvelope>();
 
                 for (int i = range.Item1; i < range.Item2; i++)
                 {
+                    //// Stop loop if canceled
+                    //if (GlobalVariables.StopLoops)
+                    //{
+                    //    loopState.Stop();
+                    //    return;
+                    //}
+
                     binPeaks.Clear();
                     isotopicEnvelopes.Clear();
                     var identification = identifications[i];
@@ -714,6 +721,13 @@ namespace FlashLFQ
                     {
                         for (int i = range.Item1; i < range.Item2; i++)
                         {
+                            //// Stop loop if canceled
+                            //if (GlobalVariables.StopLoops)
+                            //{
+                            //    loopState.Stop();
+                            //    return;
+                            //}
+
                             var identification = identificationsFromOtherRunsToLookFor[i];
 
                             ChromatographicPeak mbrFeature = new ChromatographicPeak(identification, true, fileInfo);

--- a/MassSpectrometry/MatchedFragmentIon.cs
+++ b/MassSpectrometry/MatchedFragmentIon.cs
@@ -1,0 +1,32 @@
+﻿using Chemistry;
+
+namespace MassSpectrometry
+{
+    public class MatchedFragmentIon
+    {
+        public readonly TheoreticalFragmentIon TheoreticalFragmentIon;
+        public readonly double Mz;
+        public readonly double Intensity;
+        public readonly double PpmMassError;
+
+        /// <summary>
+        /// Constructs a new MatchedFragmentIon given information about a theoretical and an experimental fragment mass spectral peak
+        /// </summary>
+        public MatchedFragmentIon(TheoreticalFragmentIon theoreticalFragmentIon, double experMz, double experIntensity)
+        {
+            TheoreticalFragmentIon = theoreticalFragmentIon;
+            Mz = experMz;
+            Intensity = experIntensity;
+            PpmMassError = ((experMz.ToMass(theoreticalFragmentIon.Charge) - theoreticalFragmentIon.Mass) / theoreticalFragmentIon.Mass) * 1e6;
+        }
+
+        /// <summary>
+        /// Summarizes a TheoreticalFragmentIon into a string for debug purposes
+        /// TODO: Convert to a usable format for output
+        /// </summary>
+        public override string ToString()
+        {
+            return TheoreticalFragmentIon.ProductType.ToString().ToLowerInvariant() + TheoreticalFragmentIon.IonNumber + "+" + TheoreticalFragmentIon.Charge + "\t;" + TheoreticalFragmentIon.Mass;
+        }
+    }
+}

--- a/MassSpectrometry/ProductType.cs
+++ b/MassSpectrometry/ProductType.cs
@@ -1,4 +1,4 @@
-namespace Proteomics.ProteolyticDigestion
+namespace MassSpectrometry
 {
     public enum ProductType
     {

--- a/MassSpectrometry/TheoreticalFragmentIon.cs
+++ b/MassSpectrometry/TheoreticalFragmentIon.cs
@@ -1,0 +1,35 @@
+﻿using Chemistry;
+
+namespace MassSpectrometry
+{
+    public class TheoreticalFragmentIon
+    {
+        /// <summary>
+        /// Constructs a new TheoreticalFragmentIon given information about its theoretical properties
+        /// </summary>
+        public TheoreticalFragmentIon(double mass, double theorIntensity, int charge, ProductType productType, int ionNumber)
+        {
+            Mass = mass;
+            Charge = charge;
+            Intensity = theorIntensity;
+            IonNumber = ionNumber;
+            ProductType = productType;
+            Mz = mass.ToMz(charge);
+        }
+
+        public double Mass { get; }
+        public int Charge { get; }
+        public double Mz { get; }
+        public double Intensity { get; }
+        public ProductType ProductType { get; }
+        public int IonNumber { get; }
+
+        /// <summary>
+        /// Summarizes a TheoreticalFragmentIon into a string for debug purposes
+        /// </summary>
+        public override string ToString()
+        {
+            return ProductType + "" + IonNumber + ";" + Mass;
+        }
+    }
+}

--- a/Proteomics/Protein/ProteinWithAppliedVariants.cs
+++ b/Proteomics/Protein/ProteinWithAppliedVariants.cs
@@ -12,12 +12,12 @@ namespace Proteomics
         public string Individual { get; }
 
         public ProteinWithAppliedVariants(string variantBaseSequence, Protein protein, IEnumerable<SequenceVariation> appliedSequenceVariations, string individual)
-            : base(variantBaseSequence, protein.Accession, organism: protein.Organism, gene_names: protein.GeneNames.ToList(),
+            : base(variantBaseSequence, protein.Accession, organism: protein.Organism, gene_names: new List<Tuple<string, string>>(protein.GeneNames),
                   oneBasedModifications: protein.OneBasedPossibleLocalizedModifications.ToDictionary(x => x.Key, x => x.Value), 
-                  proteolysisProducts: protein.ProteolysisProducts.ToList(), name: protein.Name, full_name: protein.FullName, 
+                  proteolysisProducts: new List<ProteolysisProduct>(protein.ProteolysisProducts), name: protein.Name, full_name: protein.FullName, 
                   isDecoy: protein.IsDecoy, isContaminant: protein.IsContaminant, 
-                  databaseReferences: protein.DatabaseReferences.ToList(), sequenceVariations: protein.SequenceVariations.ToList(),
-                  disulfideBonds: protein.DisulfideBonds.ToList(), databaseFilePath: protein.DatabaseFilePath)
+                  databaseReferences: new List<DatabaseReference>(protein.DatabaseReferences), sequenceVariations: new List<SequenceVariation>(protein.SequenceVariations),
+                  disulfideBonds: new List<DisulfideBond>(protein.DisulfideBonds), databaseFilePath: protein.DatabaseFilePath)
         {
             Protein = protein;
             AppliedSequenceVariations = appliedSequenceVariations != null ? appliedSequenceVariations.ToList() : new List<SequenceVariation>();

--- a/Proteomics/ProteolyticDigestion/CompactPeptideBase.cs
+++ b/Proteomics/ProteolyticDigestion/CompactPeptideBase.cs
@@ -1,4 +1,5 @@
 ﻿using Chemistry;
+using MassSpectrometry;
 using Proteomics.AminoAcidPolymer;
 using System;
 using System.Collections.Generic;

--- a/Proteomics/ProteolyticDigestion/Peptide.cs
+++ b/Proteomics/ProteolyticDigestion/Peptide.cs
@@ -178,7 +178,7 @@ namespace Proteomics.ProteolyticDigestion
                         kvp.Add(ok.Key, ok.Value);
                     }
                 }
-                yield return new PeptideWithSetModifications(Protein, OneBasedStartResidueInProtein, OneBasedEndResidueInProtein,
+                yield return new PeptideWithSetModifications(Protein, digestionParams, OneBasedStartResidueInProtein, OneBasedEndResidueInProtein,
                     PeptideDescription, MissedCleavages, kvp, numFixedMods);
                 variable_modification_isoforms++;
                 if (variable_modification_isoforms == maximumVariableModificationIsoforms)

--- a/Proteomics/ProteolyticDigestion/ProductTypeMethods.cs
+++ b/Proteomics/ProteolyticDigestion/ProductTypeMethods.cs
@@ -1,18 +1,19 @@
-﻿using System;
+﻿using MassSpectrometry;
+using System;
 using System.Collections.Generic;
 
 namespace Proteomics.ProteolyticDigestion
 {
     public static class ProductTypeMethods
     {
-        public static TerminusType IdentifyTerminusType(List<ProductType> lp)
+        public static TerminusType IdentifyTerminusType(List<ProductType> productTypes)
         {
-            if ((lp.Contains(ProductType.B) || lp.Contains(ProductType.BnoB1ions) || lp.Contains(ProductType.C) || lp.Contains(ProductType.Adot))
-                && (lp.Contains(ProductType.Y) || lp.Contains(ProductType.Zdot) || lp.Contains(ProductType.X)))
+            if ((productTypes.Contains(ProductType.B) || productTypes.Contains(ProductType.BnoB1ions) || productTypes.Contains(ProductType.C) || productTypes.Contains(ProductType.Adot))
+                && (productTypes.Contains(ProductType.Y) || productTypes.Contains(ProductType.Zdot) || productTypes.Contains(ProductType.X)))
             {
                 return TerminusType.None;
             }
-            else if (lp.Contains(ProductType.Y) || lp.Contains(ProductType.Zdot) || lp.Contains(ProductType.X))
+            else if (productTypes.Contains(ProductType.Y) || productTypes.Contains(ProductType.Zdot) || productTypes.Contains(ProductType.X))
             {
                 return TerminusType.C;
             }

--- a/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
+++ b/Proteomics/ProteolyticDigestion/ProteinDigestion.cs
@@ -19,8 +19,8 @@ namespace Proteomics.ProteolyticDigestion
             InitiatorMethionineBehavior = digestionParams.InitiatorMethionineBehavior;
             MinPeptidesLength = digestionParams.MinPeptideLength;
             MaxPeptidesLength = digestionParams.MaxPeptideLength;
-            AllKnownFixedModifications = allKnownFixedModifications;
-            VariableModifications = variableModifications;
+            AllKnownFixedModifications = allKnownFixedModifications ?? new List<ModificationWithMass>();
+            VariableModifications = variableModifications ?? new List<ModificationWithMass>();
         }
 
         public Protease Protease { get; set; }

--- a/Proteomics/ProteolyticDigestion/proteases.tsv
+++ b/Proteomics/ProteolyticDigestion/proteases.tsv
@@ -1,18 +1,18 @@
 Name	Sequences Inducing Cleavage	Sequences Preventing Cleavage	Cleavage Terminus	Cleavage Specificity	PSI-MS Accession Number	PSI-MS Name	Site Regular Expression	Notes
 Arg-C	R		C	full	MS:1001303	Arg-C	(?<=R)(?!P)	
 Asp-N	D		N	full	MS:1001304	Asp-N	(?=[BD])	
-chymotrypsin (don't cleave before proline)	F,W,Y	P	C	full	MS:1001306	Chymotrypsin	(?<=[FYWL])(?!P)	
-chymotrypsin (cleave before proline)	F,W,Y		C	full	MS:1001306	Chymotrypsin	(?<=[FYWL])	
+chymotrypsin (don't cleave before proline)	F|W|Y	P|P|P	C|C|C	full	MS:1001306	Chymotrypsin	(?<=[FYWL])(?!P)	
+chymotrypsin (cleave before proline)	F|W|Y		C|C|C	full	MS:1001306	Chymotrypsin	(?<=[FYWL])	
 CNBr	M		C	full	MS:1001307	CNBr	(?<=M)	
 Glu-C	E		C	full				
-Glu-C (with asp)	E,D		C	full				
+Glu-C (with asp)	E|D		C|C	full				
 Lys-C (don't cleave before proline)	K	P	C	full	MS:1001309	Lys-C	(?<=K)(?!P)	
 Lys-C (cleave before proline)	K		C	full	MS:1001310	Lys-C/P	(?<=K)	
 Lys-N	K		N	full				
-semi-trypsin	K,R		C	semi	MS:1001313	Trypsin/P	(?<=[KR])	
-trypsin	K,R		C	full	MS:1001313	Trypsin/P	(?<=[KR])	
+semi-trypsin	K|R		C|C	semi	MS:1001313	Trypsin/P	(?<=[KR])	
+trypsin	K|R		C|C	full	MS:1001313	Trypsin/P	(?<=[KR])	
 tryptophan oxidation	W		C	full				
-non-specific	A,C,D,E,F,G,H,I,K,L,M,N,P,Q,R,S,T,U,V,W,Y		none	full	MS:1001956	unspecific cleavage		
+non-specific	A|C|D|E|F|G|H|I|K|L|M|N|P|Q|R|S|T|U|V|W|Y		none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none|none	full	MS:1001956	unspecific cleavage		
 top-down			none	none	MS:1001955	no cleavage		
 singleN			none	SingleN	MS:1001957	single cleavage		
 singleC			none	SingleC	MS:1001958	single cleavage	

--- a/Proteomics/Proteomics.csproj
+++ b/Proteomics/Proteomics.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MassSpectrometry\MassSpectrometry.csproj" />
     <ProjectReference Include="..\MzLibUtil\MzLibUtil.csproj" />
     <ProjectReference Include="..\Chemistry\Chemistry.csproj" />
   </ItemGroup>

--- a/Test/DatabaseTests/DatabaseLoaderTests.cs
+++ b/Test/DatabaseTests/DatabaseLoaderTests.cs
@@ -219,7 +219,8 @@ namespace Test
             Protein protein = new Protein("MCSSSSSSSSSS", "accession", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>> { { 2, sampleModList.OfType<Modification>().ToList() } }, null, "name", "full_name", false, false, new List<DatabaseReference>(), new List<SequenceVariation>(), new List<DisulfideBond>());
             Assert.AreEqual(1, protein.OneBasedPossibleLocalizedModifications[2].OfType<ModificationWithMass>().Count());
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { protein }, Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins.xml"));
-            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins.xml"), true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
+            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins.xml"),
+                true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
             Assert.AreEqual(1, new_proteins.Count);
             Assert.AreEqual(1, new_proteins[0].OneBasedPossibleLocalizedModifications.Count);
             Assert.AreEqual(1, new_proteins[0].OneBasedPossibleLocalizedModifications.SelectMany(kv => kv.Value).Count());
@@ -259,7 +260,8 @@ namespace Test
             dictWithThisMod.Add("accession", value);
             var newModResEntries = ProteinDbWriter.WriteXmlDatabase(dictWithThisMod, new List<Protein> { protein }, Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins3.xml"));
             Assert.AreEqual(0, newModResEntries.Count);
-            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins3.xml"), true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
+            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins3.xml"), 
+                true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
             Assert.AreEqual(1, new_proteins.Count);
             Assert.AreEqual(1, new_proteins[0].OneBasedPossibleLocalizedModifications.Count);
             Assert.AreEqual(1, new_proteins[0].OneBasedPossibleLocalizedModifications.SelectMany(kv => kv.Value).Count());
@@ -288,7 +290,8 @@ namespace Test
 
             var newModResEntries = ProteinDbWriter.WriteXmlDatabase(dictWithThisMod, new List<Protein> { protein }, Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins2.xml"));
             Assert.AreEqual(0, newModResEntries.Count);
-            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins2.xml"), true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
+            List<Protein> new_proteins = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "test_modifications_with_proteins2.xml"),
+                true, DecoyType.None, new List<Modification>(), false, new List<string>(), out Dictionary<string, Modification> um);
             Assert.AreEqual(1, new_proteins.Count);
             Assert.AreEqual(1, new_proteins[0].OneBasedPossibleLocalizedModifications.Count);
             Assert.AreEqual(2, new_proteins[0].OneBasedPossibleLocalizedModifications.SelectMany(kv => kv.Value).Count());

--- a/Test/DatabaseTests/TestProteomicsReadWrite.cs
+++ b/Test/DatabaseTests/TestProteomicsReadWrite.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UsefulProteomicsDatabases;
+using Proteomics.ProteolyticDigestion;
 
 namespace Test
 {
@@ -14,7 +15,8 @@ namespace Test
         [Test]
         public void ReadXmlNulls()
         {
-            ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"xml2.xml"), true, DecoyType.None, null, false, null, out Dictionary<string, Modification> un);
+            var ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"xml2.xml"), true, DecoyType.None,
+                null, false, null, out Dictionary<string, Modification> un);
         }
 
         [Test]
@@ -61,7 +63,7 @@ namespace Test
             ModificationMotif.TryGetMotif("X", out ModificationMotif motif);
             var nice = new List<Modification>
             {
-                new ModificationWithLocation("fayk", "mt", motif,TerminusLocalization.Any,null)
+                new ModificationWithLocation("fayk", "mt", motif, TerminusLocalization.Any, null)
             };
 
             List<Protein> ok = ProteinDbLoader.LoadProteinFasta(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"test_ensembl.pep.all.fasta"), true, DecoyType.None, false,
@@ -118,8 +120,9 @@ namespace Test
             ModificationMotif.TryGetMotif("X", out ModificationMotif motif);
             var nice = new List<Modification>
             {
-                new ModificationWithLocation("fayk", "mt", motif,TerminusLocalization.Any,null)
+                new ModificationWithLocation("fayk", "mt", motif, TerminusLocalization.Any, null)
             };
+
             List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"xml2.xml"), true, DecoyType.None, nice, false, null,
                 out Dictionary<string, Modification> un);
             ProteinDbWriter.WriteFastaDatabase(ok, Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml_test.fasta"), "|");
@@ -180,8 +183,8 @@ namespace Test
                 out Dictionary<string, Modification> un);
             var newModResEntries = ProteinDbWriter.WriteXmlDatabase(new_mods, ok, Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml2.xml"));
             Assert.AreEqual(1, newModResEntries.Count);
-            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml2.xml"), true, DecoyType.None, nice, false, new List<string>(),
-                out un);
+            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml2.xml"), true, DecoyType.None,
+                nice, false, new List<string>(), out un);
 
             Assert.AreEqual(ok.Count, ok2.Count);
             Assert.True(Enumerable.Range(0, ok.Count).All(i => ok[i].BaseSequence == ok2[i].BaseSequence));
@@ -228,8 +231,8 @@ namespace Test
 
             IEnumerable<string> modTypesToExclude = new List<string>();
             IEnumerable<Modification> allKnownModifications = new List<Modification>();
-            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"differentlyConstuctedProteins.xml"), true,
-                DecoyType.None, allKnownModifications, false, modTypesToExclude, out Dictionary<string, Modification> un);
+            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"differentlyConstuctedProteins.xml"), true, DecoyType.None,
+                allKnownModifications, false, modTypesToExclude, out Dictionary<string, Modification> un);
             Assert.AreEqual(p1.Accession, ok[0].Accession);
             Assert.AreEqual(p2.Accession, ok[1].Accession);
             Assert.AreEqual(p1.Name, ok[0].Name);
@@ -266,19 +269,20 @@ namespace Test
 
             List<DisulfideBond> disulfideBonds = new List<DisulfideBond> { new DisulfideBond(1, "ds1"), new DisulfideBond(2, 3, "ds2") };
 
-            Protein p1 = new Protein("SEQENCE",
-                                        "a1",
-                                        gene_names: gene_names,
-                                        oneBasedModifications: oneBasedModifications,
-                                        proteolysisProducts: proteolysisProducts,
-                                        name: name,
-                                        full_name: full_name,
-                                        isDecoy: false,
-                                        isContaminant: true,
-                                        databaseReferences: databaseReferences,
-                                        sequenceVariations: sequenceVariations,
-                                        disulfideBonds: disulfideBonds,
-                                        databaseFilePath: Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"bnueiwhf.xml"));
+            Protein p1 = new Protein(
+                "SEQENCE",
+                "a1",
+                gene_names: gene_names,
+                oneBasedModifications: oneBasedModifications,
+                proteolysisProducts: proteolysisProducts,
+                name: name,
+                full_name: full_name,
+                isDecoy: false,
+                isContaminant: true,
+                databaseReferences: databaseReferences,
+                sequenceVariations: sequenceVariations,
+                disulfideBonds: disulfideBonds,
+                databaseFilePath: Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"bnueiwhf.xml"));
 
             // Generate data for files
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { p1 },
@@ -286,8 +290,8 @@ namespace Test
 
             IEnumerable<string> modTypesToExclude = new List<string>();
             IEnumerable<Modification> allKnownModifications = new List<Modification>();
-            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"bnueiwhf.xml"), true,
-                DecoyType.None, allKnownModifications, true, modTypesToExclude, out Dictionary<string, Modification> unknownModifications);
+            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"bnueiwhf.xml"), true, DecoyType.None,
+                allKnownModifications, true, modTypesToExclude, out Dictionary<string, Modification> unknownModifications);
             Assert.AreEqual(p1.Accession, ok[0].Accession);
             Assert.AreEqual(p1.BaseSequence, ok[0].BaseSequence);
             Assert.AreEqual(p1.DatabaseReferences.First().Id, ok[0].DatabaseReferences.First().Id);
@@ -350,11 +354,11 @@ namespace Test
                 new ModificationWithLocation("fayk", "mt", motif,TerminusLocalization.Any,null)
             };
 
-            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"xml.xml"), true,
-                DecoyType.None, nice, false, null, out Dictionary<string, Modification> un);
+            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"xml.xml"), true, DecoyType.None,
+                nice, false, null, out Dictionary<string, Modification> un);
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), ok, Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml.xml"));
-            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml.xml"), true,
-                DecoyType.None, nice, false, new List<string>(), out un);
+            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_xml.xml"), true, DecoyType.None,
+                nice, false, new List<string>(), out un);
 
             Assert.AreEqual(ok[0].SequenceVariations.Count(), ok2[0].SequenceVariations.Count());
             Assert.AreEqual(ok[0].SequenceVariations.First().OneBasedBeginPosition, ok2[0].SequenceVariations.First().OneBasedBeginPosition);
@@ -373,11 +377,11 @@ namespace Test
                 new ModificationWithLocation("fayk", "mt", motif,TerminusLocalization.Any,null)
             };
 
-            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"seqvartests.xml"), true,
-                DecoyType.None, nice, false, new List<string>(), out Dictionary<string, Modification> un);
+            List<Protein> ok = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"seqvartests.xml"), true, DecoyType.None,
+                nice, false, new List<string>(), out Dictionary<string, Modification> un);
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), ok, Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_seqvartests.xml"));
-            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_seqvartests.xml"), true,
-                DecoyType.None, nice, false, new List<string>(), out un);
+            List<Protein> ok2 = ProteinDbLoader.LoadProteinXML(Path.Combine(TestContext.CurrentContext.TestDirectory, "DatabaseTests", @"rewrite_seqvartests.xml"), true, DecoyType.None,
+                nice, false, new List<string>(), out un);
 
             Assert.AreEqual(ok[0].SequenceVariations.Count(), ok2[0].SequenceVariations.Count());
             Assert.AreEqual(ok[0].SequenceVariations.First().OneBasedBeginPosition, ok2[0].SequenceVariations.First().OneBasedBeginPosition);

--- a/Test/DoubleProtease.tsv
+++ b/Test/DoubleProtease.tsv
@@ -1,0 +1,4 @@
+Name	Sequences Inducing Cleavage	Sequences Preventing Cleavage	Cleavage Terminus	Cleavage Specificity	PSI-MS Accession Number	PSI-MS Name	Site Regular Expression	Notes
+Test1	K|R|D	"P,D|P|"	C|N|N	full				
+Test2	K|D		C|C	full				
+Test3	K|		C|N	full				

--- a/Test/MyPeptideTest.cs
+++ b/Test/MyPeptideTest.cs
@@ -1,11 +1,13 @@
 ﻿using Chemistry;
 using NUnit.Framework;
 using Proteomics;
-using Proteomics.ProteolyticDigestion;
 using Proteomics.AminoAcidPolymer;
+using Proteomics.ProteolyticDigestion;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using static Chemistry.PeriodicTable;
+using MassSpectrometry;
 
 namespace Test
 {
@@ -16,7 +18,7 @@ namespace Test
         public static void TestGoodPeptide()
         {
             var prot = new Protein("MNNNKQQQQ", null);
-            var protease = new Protease("CustomizedProtease", new List<string> { "K" }, new List<string>(), TerminusType.C, CleavageSpecificity.Full, null, null, null);
+            var protease = new Protease("CustomizedProtease", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
             DigestionParams digestionParams = new DigestionParams(
                 protease: protease.Name,
@@ -47,11 +49,8 @@ namespace Test
         {
             List<ModificationWithMass> fixedModifications = new List<ModificationWithMass>();
             var prot = new Protein("MNNNKQQQQ", null, null, null, new Dictionary<int, List<Modification>>(), new List<ProteolysisProduct> { new ProteolysisProduct(5, 6, "lala") });
-            var protease = new Protease("Custom Protease", null, null, TerminusType.None, CleavageSpecificity.None, null, null, null);
-
             DigestionParams digestionParams = new DigestionParams(minPeptideLength: 5);
             var ye = prot.Digest(digestionParams, fixedModifications, new List<ModificationWithMass>()).ToList();
-
             Assert.AreEqual(3, ye.Count);
         }
 
@@ -59,7 +58,7 @@ namespace Test
         public static void TestBadPeptide()
         {
             var prot = new Protein("MNNNKQQXQ", null);
-            var protease = new Protease("Custom Protease7", new List<string> { "K" }, new List<string>(), TerminusType.C, CleavageSpecificity.Full, null, null, null);
+            var protease = new Protease("Custom Protease7", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
             DigestionParams digestionParams = new DigestionParams(
                 protease: protease.Name,
@@ -109,7 +108,6 @@ namespace Test
         public static void TestPeptideWithFixedModifications()
         {
             var prot = new Protein("M", null);
-            var protease = new Protease("Custom Protease", new List<string> { "K" }, new List<string>(), TerminusType.C, CleavageSpecificity.Full, null, null, null);
             List<ModificationWithMass> fixedMods = new List<ModificationWithMass>();
             ModificationMotif.TryGetMotif("M", out ModificationMotif motif);
             fixedMods.Add(new ModificationWithMassAndCf("ProtNmod", null, motif, TerminusLocalization.NProt, Chemistry.ChemicalFormula.ParseFormula("H"), GetElement(1).PrincipalIsotope.AtomicMass));

--- a/Test/SeqCoverageTests.cs
+++ b/Test/SeqCoverageTests.cs
@@ -1,0 +1,106 @@
+﻿using NUnit.Framework;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    [TestFixture]
+    public class SeqCoverageTests
+    {
+        [Test]
+        public static void MultipleProteaseSelectionTest()
+        {
+            Protein ParentProtein = new Protein("MOAT", "accession1");
+
+            var protease = new Protease("TestProtease1", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("O", TerminusType.C), new Tuple<string, TerminusType>("T", TerminusType.N) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
+            ProteaseDictionary.Dictionary.Add(protease.Name, protease);
+            DigestionParams multiProtease = new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList = ParentProtein.Digest(multiProtease, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            var sequences = digestedList.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences.Count == 3);
+            Assert.That(sequences.Contains("MO"));
+            Assert.That(sequences.Contains("A"));
+            Assert.That(sequences.Contains("T"));
+        }
+
+        [Test]
+        public static void MultipleProteaseSelectionTestMissedCleavage()
+        {
+            Protein ParentProtein = new Protein("MOAT", "accession1");
+
+            var protease = new Protease("TestProtease2", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("O", TerminusType.C), new Tuple<string, TerminusType>("T", TerminusType.N) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
+            ProteaseDictionary.Dictionary.Add(protease.Name, protease);
+            DigestionParams multiProtease = new DigestionParams(protease: protease.Name, maxMissedCleavages: 1, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList = ParentProtein.Digest(multiProtease, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            var sequences = digestedList.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences.Count == 5);
+            Assert.That(sequences.Contains("MOA"));
+            Assert.That(sequences.Contains("AT"));
+            Assert.That(sequences.Contains("MO"));
+            Assert.That(sequences.Contains("A"));
+            Assert.That(sequences.Contains("T"));
+        }
+
+        [Test]
+        public static void MultipleProteaseSelectionTestPreventCleavage()
+        {
+            Protein ParentProtein = new Protein("MOAT", "accession1");
+
+            var protease = new Protease("TestProtease3", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("O", TerminusType.C), new Tuple<string, TerminusType>("T", TerminusType.N) }, new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("A", TerminusType.C) }, CleavageSpecificity.Full, null, null, null);
+            ProteaseDictionary.Dictionary.Add(protease.Name, protease);
+            DigestionParams multiProtease = new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList = ParentProtein.Digest(multiProtease, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            var sequences = digestedList.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences.Count == 2);
+            Assert.That(sequences.Contains("MOA"));
+            Assert.That(sequences.Contains("T"));
+        }
+
+        [Test]
+        public static void ReadCustomFile()
+        {
+            Protein ParentProtein = new Protein("OKAREDY", "accession1");
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "DoubleProtease.tsv");
+            Assert.That(File.Exists(path));
+
+            var proteaseDict = ProteaseDictionary.LoadProteaseDictionary(path);
+            Assert.That(proteaseDict.ContainsKey("Test1"));
+            Assert.That(proteaseDict.ContainsKey("Test2"));
+            Assert.That(proteaseDict.ContainsKey("Test3"));
+            ProteaseDictionary.Dictionary.Add("Test1", proteaseDict["Test1"]);
+
+            DigestionParams multiProtease1 = new DigestionParams(protease: "Test1", maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList1 = ParentProtein.Digest(multiProtease1, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            ProteaseDictionary.Dictionary.Remove("Test1");
+
+            var sequences = digestedList1.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences.Count == 3);
+            Assert.That(sequences.Contains("OK"));
+            Assert.That(sequences.Contains("A"));
+            Assert.That(sequences.Contains("REDY"));
+
+            ProteaseDictionary.Dictionary.Add("Test2", proteaseDict["Test2"]);
+            DigestionParams multiProtease2 = new DigestionParams(protease: "Test2", maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList2 = ParentProtein.Digest(multiProtease2, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            ProteaseDictionary.Dictionary.Remove("Test2");
+            var sequences2 = digestedList2.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences2.Count == 3);
+            Assert.That(sequences2.Contains("OK"));
+            Assert.That(sequences2.Contains("ARED"));
+            Assert.That(sequences2.Contains("Y"));
+
+            ProteaseDictionary.Dictionary.Add("Test3", proteaseDict["Test3"]);
+            DigestionParams multiProtease3 = new DigestionParams(protease: "Test3", maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            var digestedList3 = ParentProtein.Digest(multiProtease3, new List<ModificationWithMass>(), new List<ModificationWithMass>()).ToList();
+            ProteaseDictionary.Dictionary.Remove("Test3");
+            var sequences3 = digestedList3.Select(p => p.BaseSequence).ToList();
+            Assert.That(sequences3.Count == 2);
+            Assert.That(sequences3.Contains("OK"));
+            Assert.That(sequences3.Contains("AREDY"));
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -45,6 +45,7 @@
     <Compile Include="FakeMsDataFile.cs" />
     <Compile Include="ModFitsTest.cs" />
     <Compile Include="MyPeptideTest.cs" />
+    <Compile Include="SeqCoverageTests.cs" />
     <Compile Include="TestCZE.cs" />
     <Compile Include="TestMgf.cs" />
     <Compile Include="TestMzML.cs" />
@@ -128,6 +129,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="DatabaseTests\fasta.fasta">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="DoubleProtease.tsv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />

--- a/UsefulProteomicsDatabases/DecoyType.cs
+++ b/UsefulProteomicsDatabases/DecoyType.cs
@@ -5,26 +5,32 @@ namespace UsefulProteomicsDatabases
 {
     public enum DecoyType
     {
+        /// <summary>
+        /// Generate no decoy
+        /// </summary>
         None,
+
+        /// <summary>
+        /// Reverse the protein sequence, possibly keeping the initiating methionine in place
+        /// </summary>
         Reverse,
+
+        /// <summary>
+        /// No clue...
+        /// </summary>
         Slide,
+
+        /// <summary>
+        /// Generate decoy by:
+        /// 1. simulating proteolytic digesiton (if any)
+        /// 2. shuffling the resulting peptides, keeping the cleavage site and possibly initiating methionine in place,
+        /// 3. concatenating them back together into
+        /// </summary>
         Shuffle,
+
+        /// <summary>
+        /// No clue... not implemented
+        /// </summary>
         Random
-    }
-
-    public class DecoyTypeClass
-    {
-        public DecoyTypeClass(DecoyType decoyType, Protease protease)
-        {
-            DecoyType = decoyType;
-            Protease = protease;
-            if (DecoyType == DecoyType.Shuffle && protease == null)
-            {
-                throw new ArgumentException("DecoyType of shuffled must have a protease specified");
-            }
-        }
-
-        public DecoyType DecoyType { get; private set; }
-        public Protease Protease { get; private set; }
     }
 }

--- a/UsefulProteomicsDatabases/ProteinDbLoader.cs
+++ b/UsefulProteomicsDatabases/ProteinDbLoader.cs
@@ -50,7 +50,7 @@ namespace UsefulProteomicsDatabases
         /// <param name="unknownModifications"></param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times")]
-        public static List<Protein> LoadProteinXML(string proteinDbLocation, bool generateTargetProteins, DecoyType decoyType, IEnumerable<Modification> allKnownModifications,
+        public static List<Protein> LoadProteinXML(string proteinDbLocation, bool generateTargets, DecoyType decoyType, IEnumerable<Modification> allKnownModifications,
             bool isContaminant, IEnumerable<string> modTypesToExclude, out Dictionary<string, Modification> unknownModifications)
         {
             List<Modification> prespecified = GetPtmListFromProteinXml(proteinDbLocation);
@@ -63,7 +63,7 @@ namespace UsefulProteomicsDatabases
                 mod_dict = GetModificationDict(new HashSet<Modification>(prespecified.Concat(allKnownModifications)));
             }
 
-            List<Protein> result = new List<Protein>();
+            List<Protein> targets = new List<Protein>();
             unknownModifications = new Dictionary<string, Modification>();
             using (var stream = new FileStream(proteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -86,13 +86,14 @@ namespace UsefulProteomicsDatabases
                         if (xml.NodeType == XmlNodeType.EndElement || xml.IsEmptyElement)
                         {
                             var newProteinEntries = block.ParseEndElement(xml, mod_dict, modTypesToExclude, unknownModifications,
-                                generateTargetProteins, decoyType, isContaminant, proteinDbLocation);
-                            result.AddRange(newProteinEntries);
+                                isContaminant, proteinDbLocation);
+                            targets.AddRange(newProteinEntries);
                         }
                     }
                 }
             }
-            return result;
+            List<Protein> decoys = DecoyProteinGenerator.GenerateDecoys(targets, decoyType);
+            return (generateTargets ? targets : new List<Protein>()).Concat(decoyType != DecoyType.None ? decoys : new List<Protein>()).ToList();
         }
 
         /// <summary>
@@ -147,8 +148,8 @@ namespace UsefulProteomicsDatabases
         /// Load a protein fasta database, using regular expressions to get various aspects of the headers. The first regex capture group is used as each field.
         /// </summary>
         /// <param name="proteinDbLocation"></param>
-        /// <param name="originalTarget"></param>
-        /// <param name="onTheFlyDecoys"></param>
+        /// <param name="generateTargets"></param>
+        /// <param name="decoyType"></param>
         /// <param name="isContaminant"></param>
         /// <param name="accessionRegex"></param>
         /// <param name="fullNameRegex"></param>
@@ -157,7 +158,7 @@ namespace UsefulProteomicsDatabases
         /// <param name="organismRegex"></param>
         /// <param name="errors"></param>
         /// <returns></returns>
-        public static List<Protein> LoadProteinFasta(string proteinDbLocation, bool originalTarget, DecoyType onTheFlyDecoys, bool isContaminant,
+        public static List<Protein> LoadProteinFasta(string proteinDbLocation, bool generateTargets, DecoyType decoyType, bool isContaminant,
             FastaHeaderFieldRegex accessionRegex, FastaHeaderFieldRegex fullNameRegex, FastaHeaderFieldRegex nameRegex,
             FastaHeaderFieldRegex geneNameRegex, FastaHeaderFieldRegex organismRegex, out List<string> errors)
         {
@@ -171,7 +172,7 @@ namespace UsefulProteomicsDatabases
             errors = new List<string>();
             Regex substituteWhitespace = new Regex(@"\s+");
 
-            List<Protein> result = new List<Protein>();
+            List<Protein> targets = new List<Protein>();
 
             using (var stream = new FileStream(proteinDbLocation, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -221,44 +222,15 @@ namespace UsefulProteomicsDatabases
                             unique_identifier++;
                         }
                         unique_accessions.Add(accession);
-                        if (originalTarget)
+                        Protein protein = new Protein(sequence, accession, organism, geneName, name: name, full_name: fullName,
+                            isContaminant: isContaminant, databaseFilePath: proteinDbLocation);
+                        if (protein.Length == 0)
                         {
-                            Protein protein = new Protein(sequence, accession, organism, geneName, name: name, full_name: fullName,
-                                isContaminant: isContaminant, databaseFilePath: proteinDbLocation);
-                            if (protein.Length == 0)
-                            {
-                                errors.Add("Line" + line + ", Protein Length of 0: " + protein.Name + " was skipped from database: " + proteinDbLocation);
-                            }
-                            else
-                            {
-                                result.Add(protein);
-                            }
+                            errors.Add("Line" + line + ", Protein Length of 0: " + protein.Name + " was skipped from database: " + proteinDbLocation);
                         }
-
-                        if (onTheFlyDecoys == DecoyType.Reverse)
+                        else
                         {
-                            char[] sequence_array = sequence.ToCharArray();
-                            int starts_with_met = sequence.StartsWith("M", StringComparison.Ordinal) ? 1 : 0;
-                            Array.Reverse(sequence_array, starts_with_met, sequence.Length - starts_with_met); // Do not include the initiator methionine in reversal!!!
-                            var reversed_sequence = new string(sequence_array);
-                            Protein decoy_protein = new Protein(reversed_sequence, "DECOY_" + accession, organism, geneName, name: name, full_name: fullName,
-                                isDecoy: true, isContaminant: isContaminant, databaseFilePath: proteinDbLocation);
-                            result.Add(decoy_protein);
-                        }
-                        else if (onTheFlyDecoys == DecoyType.Slide)
-                        {
-                            int numSlides = 20;
-                            char[] sequence_array_unslide = sequence.ToCharArray();
-                            char[] sequence_array_slide = sequence.ToCharArray();
-                            bool starts_with_met_slide = sequence.StartsWith("M", StringComparison.Ordinal);
-                            for (int i = starts_with_met_slide ? 1 : 0; i < sequence.Length; i++)
-                            {
-                                sequence_array_slide[i] = sequence_array_unslide[DecoyProteinGenerator.GetOldShuffleIndex(i, numSlides, sequence.Length, starts_with_met_slide)];
-                            }
-                            string slide_sequence = new string(sequence_array_slide);
-                            Protein decoy_protein_slide = new Protein(slide_sequence, "DECOY_" + accession, organism, geneName, name: name, full_name: fullName,
-                                isDecoy: true, isContaminant: isContaminant, databaseFilePath: proteinDbLocation);
-                            result.Add(decoy_protein_slide);
+                            targets.Add(protein);
                         }
 
                         accession = null;
@@ -275,22 +247,23 @@ namespace UsefulProteomicsDatabases
                     }
                 }
             }
-            if (!result.Any())
+            if (!targets.Any())
             {
                 errors.Add("Error: No proteins could be read from the database: " + proteinDbLocation);
             }
-            return result;
+            List<Protein> decoys = DecoyProteinGenerator.GenerateDecoys(targets, decoyType);
+            return (generateTargets ? targets : new List<Protein>()).Concat(decoyType != DecoyType.None ? decoys : new List<Protein>()).ToList();
         }
 
         /// <summary>
         /// Merge proteins that have the same accession, sequence, and contaminant designation.
         /// </summary>
-        /// <param name="merge_these"></param>
+        /// <param name="mergeThese"></param>
         /// <returns></returns>
-        public static IEnumerable<Protein> Merge_proteins(IEnumerable<Protein> merge_these)
+        public static IEnumerable<Protein> MergeProteins(IEnumerable<Protein> mergeThese)
         {
             Dictionary<Tuple<string, string, bool, bool>, List<Protein>> proteinsByAccessionSequenceContaminant = new Dictionary<Tuple<string, string, bool, bool>, List<Protein>>();
-            foreach (Protein p in merge_these)
+            foreach (Protein p in mergeThese)
             {
                 Tuple<string, string, bool, bool> key = new Tuple<string, string, bool, bool>(p.Accession, p.BaseSequence, p.IsContaminant, p.IsDecoy);
                 if (!proteinsByAccessionSequenceContaminant.TryGetValue(key, out List<Protein> bundled))

--- a/UsefulProteomicsDatabases/ProteinXmlEntry.cs
+++ b/UsefulProteomicsDatabases/ProteinXmlEntry.cs
@@ -140,12 +140,12 @@ namespace UsefulProteomicsDatabases
         /// <param name="modTypesToExclude"></param>
         /// <param name="unknownModifications"></param>
         /// <param name="generateTargetProteins"></param>
-        /// <param name="decoyType"></param>
+        /// <param name="decoySetting"></param>
         /// <param name="isContaminant"></param>
         /// <param name="proteinDbLocation"></param>
         /// <returns></returns>
         public List<Protein> ParseEndElement(XmlReader xml, Dictionary<string, IList<Modification>> mod_dict, IEnumerable<string> modTypesToExclude,
-            Dictionary<string, Modification> unknownModifications, bool generateTargetProteins, DecoyType decoyType, bool isContaminant, string proteinDbLocation)
+            Dictionary<string, Modification> unknownModifications, bool isContaminant, string proteinDbLocation)
         {
             List<Protein> result = new List<Protein>();
             if (xml.Name == "feature")
@@ -166,7 +166,7 @@ namespace UsefulProteomicsDatabases
             }
             else if (xml.Name == "entry")
             {
-                result.AddRange(ParseEntryEndElement(xml, generateTargetProteins, decoyType, isContaminant, proteinDbLocation));
+                result.AddRange(ParseEntryEndElement(xml, isContaminant, proteinDbLocation));
             }
             return result;
         }
@@ -180,28 +180,14 @@ namespace UsefulProteomicsDatabases
         /// <param name="isContaminant"></param>
         /// <param name="proteinDbLocation"></param>
         /// <returns></returns>
-        public List<Protein> ParseEntryEndElement(XmlReader xml, bool generateTargetProteins, DecoyType decoyType, bool isContaminant, string proteinDbLocation)
+        public List<Protein> ParseEntryEndElement(XmlReader xml,  bool isContaminant, string proteinDbLocation)
         {
             List<Protein> result = new List<Protein>();
             if (Accession != null && Sequence != null)
             {
-                if (generateTargetProteins)
-                {
-                    var protein = new Protein(Sequence, Accession, Organism, GeneNames, OneBasedModifications, ProteolysisProducts, Name, FullName,
-                        false, isContaminant, DatabaseReferences, SequenceVariations, DisulfideBonds, proteinDbLocation);
-                    result.Add(protein);
-                }
-
-                if (decoyType == DecoyType.Reverse)
-                {
-                    var decoyProtein = DecoyProteinGenerator.GenerateReverseDecoy(this, isContaminant, proteinDbLocation);
-                    result.Add(decoyProtein);
-                }
-                else if (decoyType == DecoyType.Slide)
-                {
-                    var decoyProtein = DecoyProteinGenerator.GenerateSlideDecoy(this, isContaminant, proteinDbLocation);
-                    result.Add(decoyProtein);
-                }
+                var protein = new Protein(Sequence, Accession, Organism, GeneNames, OneBasedModifications, ProteolysisProducts, Name, FullName,
+                    false, isContaminant, DatabaseReferences, SequenceVariations, DisulfideBonds, proteinDbLocation);
+                result.Add(protein);
             }
             Clear();
             return result;
@@ -214,7 +200,8 @@ namespace UsefulProteomicsDatabases
         /// <param name="mod_dict"></param>
         /// <param name="modTypesToExclude"></param>
         /// <param name="unknownModifications"></param>
-        public void ParseFeatureEndElement(XmlReader xml, Dictionary<string, IList<Modification>> mod_dict, IEnumerable<string> modTypesToExclude, Dictionary<string, Modification> unknownModifications)
+        public void ParseFeatureEndElement(XmlReader xml, Dictionary<string, IList<Modification>> mod_dict, IEnumerable<string> modTypesToExclude, 
+            Dictionary<string, Modification> unknownModifications)
         {
             if (FeatureType == "modified residue")
             {


### PR DESCRIPTION
* Transfer over protein digestion code & fix codecov reports

Make a ProteolyticDigestion namespace to further separate the two Peptide classes

* Improve test organization

* Name ProteolyticDigestion folder to match new namespace

* Remove #regions where not helpful

* More small changes

* Fixed bug with non-VCF line SeqVar entries

* style consistency

* Simplify making proteinswithsetmods, making MM work with the new code

* Roll back changes to sharplearning

* Added some tests

* Changing decoy generation flow

* Fixing merge issues

* Fix test issue

* before clearing out digestion stuff

* removed shuffle progress

* Merge in Rob's changes

* Fix bad fasta test and restrict sharplearning flashLFQ version